### PR TITLE
商品を選択しても登録されない不具合修正

### DIFF
--- a/Event.php
+++ b/Event.php
@@ -13,6 +13,7 @@ namespace Plugin\RelatedProduct;
 
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 
 class Event
 {


### PR DESCRIPTION
use 宣言していないため、RedirectResponse の instanceof が false を返してしまい、
その後の処理が実行されない。
