### PR TITLE
関連商品プラグインの修正

### DIFF
--- a/Controller/Admin/RelatedProductController.php
+++ b/Controller/Admin/RelatedProductController.php
@@ -33,10 +33,31 @@ class RelatedProductController
                 ->getQuery()
                 ->getResult();
 
+            // 表示されている商品は検索結果に含めない
+            $productId = $request->get('product_id');
+            $ProductsData = array();
+            $count = count($Products);
+            $i = 0;
+            for($i = 0; $i < $count; $i++) {
+                $Product = $Products[$i];
+                if ($Product->getId() != $productId) {
+                    $ProductsData[] = $Product;
+                }
+                if ($i >= 10) {
+                    break;
+                }
+            }
+
+            $message = '';
+            if ($count > $i) {
+                $message = '検索結果の上限を超えています。検索条件を設定してください。';
+            }
+
             return $app->renderView(
                 'RelatedProduct/Resource/template/Admin/modal_result.twig',
                 array(
-                    'Products' => $Products,
+                    'Products' => $ProductsData,
+                    'message' => $message,
                 )
             );
 

--- a/Event.php
+++ b/Event.php
@@ -176,7 +176,8 @@ class Event
         $modal = $app->renderView(
             'RelatedProduct/Resource/template/Admin/modal.twig',
             array(
-                'searchForm' => $searchForm->createView()
+                'searchForm' => $searchForm->createView(),
+                'Product' => $Product,
             )
         );
         $oldElement = $crawler

--- a/Resource/template/Admin/modal.twig
+++ b/Resource/template/Admin/modal.twig
@@ -29,7 +29,8 @@
             var formCatIdVal = $("#{{ searchForm.category_id.vars.id }}").val();
             var data = {
                 id: formIdVal,
-                category_id: formCatIdVal
+                category_id: formCatIdVal,
+                product_id: {{ Product.id ? Product.id : 0 }}
             };
             $("#searchResult")
                     .children()
@@ -57,7 +58,7 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><svg class="cb cb-close" aria-hidden="true"><use xlink:href="#cb-close"></svg></button>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span class="modal-close" aria-hidden="true">&times;</span></button>
                 <h4 class="modal-title" id="myModalLabel">商品検索</h4>
             </div>
             <div class="modal-body">

--- a/Resource/template/Admin/modal_result.twig
+++ b/Resource/template/Admin/modal_result.twig
@@ -8,6 +8,9 @@
  file that was distributed with this source code.
 #}
 
+{% if message is not empty  %}
+<p class="text-danger">{{ message }}</p>
+{% endif %}
 <div class="table-responsive">
     <table class="table">
         <tbody>

--- a/Resource/template/Admin/related_product.twig
+++ b/Resource/template/Admin/related_product.twig
@@ -8,6 +8,20 @@
  file that was distributed with this source code.
 #}
 
+{% block javascript %}
+<script>
+$(function() {
+    $(document).on('click', '.delete', function() {
+        var data = $(this).data();
+        $('#admin_product_related_collection_' + data.id + '_ChildProduct').val('');
+        $('#view_' + data.id).text('');
+        $('#admin_product_related_collection_' + data.id + '_content' ).val('');
+        $('#searchResult').children().remove();
+    });
+});
+</script>
+{% endblock javascript %}
+
 </div>
 <div class="box accordion">
 
@@ -33,6 +47,9 @@
                 </div>
                 <label id="view_{{ loop.index0 }}" class="control-label"></label>
                 {{ form_widget(child.ChildProduct, { attr: { style: 'display: none' } }) }}
+                {% if child.vars.value.id is not null %}
+                    <button type="button" class="btn btn-default text-right delete" data-id="{{ loop.index0 }}">削除</button>
+                {% endif %}
             </div>
             <div class="form-group">
                 {{ form_label(child.content) }}


### PR DESCRIPTION
- 関連商品検索時に編集中の商品が表示されないように修正 #4
- 追加した関連商品を削除する機能を追加 #12
- 関連商品検索時の検索結果上限数を10件に設定 #14 
