### PR TITLE
関連商品削除に伴うエラーを修正

### DIFF
--- a/Entity/RelatedProduct.php
+++ b/Entity/RelatedProduct.php
@@ -11,6 +11,8 @@
 
 namespace Plugin\RelatedProduct\Entity;
 
+use Eccube\Util\EntityUtil;
+
 class RelatedProduct
 {
     private $id;
@@ -44,6 +46,9 @@ class RelatedProduct
 
     public function getProduct()
     {
+        if (EntityUtil::isEmpty($this->Product)) {
+            return null;
+        }
         return $this->Product;
     }
 
@@ -68,6 +73,9 @@ class RelatedProduct
 
     public function getChildProduct()
     {
+        if (EntityUtil::isEmpty($this->ChildProduct)) {
+            return null;
+        }
         return $this->ChildProduct;
     }
 

--- a/Event.php
+++ b/Event.php
@@ -31,7 +31,7 @@ class Event
 
         $id = $app['request']->attributes->get('id');
         $Product = $app['eccube.repository.product']->find($id);
-        $RelatedProducts = $app['eccube.plugin.repository.related_product']->findBy(array('Product' => $Product));
+        $RelatedProducts = $app['eccube.plugin.repository.related_product']->getChildProducts($Product);
 
         if (count($RelatedProducts) > 0) {
             $twig = $app->renderView(
@@ -145,10 +145,7 @@ class Event
             $Product = new \Eccube\Entity\Product();
         }
 
-        $RelatedProducts = $app['eccube.plugin.repository.related_product']->findBy(
-            array(
-                'Product' => $Product,
-            ));
+        $RelatedProducts = $app['eccube.plugin.repository.related_product']->getChildProducts($Product);
 
         $loop = 5 - count($RelatedProducts);
         for ($i = 0; $i < $loop; $i++) {

--- a/Repository/RelatedProductRepository.php
+++ b/Repository/RelatedProductRepository.php
@@ -34,11 +34,14 @@ class RelatedProductRepository extends EntityRepository
     /**
      * 関連商品の配列を取得する (削除フラグを考慮)
      *
-     * @param $Product
+     * @param \Eccube\Entity\Product $Product
      * @return array
      */
     public function getChildProducts($Product)
     {
+        if (!$Product || is_null($Product->getId())) {
+            return array();
+        }
         $qb = $this->createQueryBuilder('rp');
         return $qb
             ->innerJoin('Eccube\Entity\Product', 'cp', Join::WITH, 'rp.ChildProduct = cp')

--- a/Repository/RelatedProductRepository.php
+++ b/Repository/RelatedProductRepository.php
@@ -12,6 +12,7 @@
 namespace Plugin\RelatedProduct\Repository;
 
 use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\Query\Expr\Join;
 
 /**
  * CategoryTotalCountRepository
@@ -28,5 +29,24 @@ class RelatedProductRepository extends EntityRepository
         foreach ($Children as $Child) {
             $em->remove($Child);
         }
+    }
+
+    /**
+     * 関連商品の配列を取得する (削除フラグを考慮)
+     *
+     * @param $Product
+     * @return array
+     */
+    public function getChildProducts($Product)
+    {
+        $qb = $this->createQueryBuilder('rp');
+        return $qb
+            ->innerJoin('Eccube\Entity\Product', 'cp', Join::WITH, 'rp.ChildProduct = cp')
+            ->andWhere('cp.del_flg = 0')
+            ->andWhere('rp.Product = :Product')
+            ->setParameter('Product', $Product)
+            ->getQuery()
+            ->getResult()
+        ;
     }
 }


### PR DESCRIPTION
関連商品登録後に関連商品の削除フラグを1に変更すると、元の商品の編集画面と詳細画面でエラーが発生。

Eccube\Util\EntityUtil::isEmpty()でエンティティの存在を確認した上で、削除フラグを考慮して関連商品を取得する処理を追加。
