### PR TITLE
関連商品登録数をハードコーディングからconfigに移動

### DIFF
--- a/Event.php
+++ b/Event.php
@@ -150,7 +150,7 @@ class Event
                 'Product' => $Product,
             ));
 
-        $loop = 5 - count($RelatedProducts);
+        $loop = $this->app['config']['plg_related_product_count'] - count($RelatedProducts);
         for ($i = 0; $i < $loop; $i++) {
             $RelatedProduct = new \Plugin\RelatedProduct\Entity\RelatedProduct();
             $RelatedProduct

--- a/Resource/template/Admin/modal.twig
+++ b/Resource/template/Admin/modal.twig
@@ -13,7 +13,7 @@
 <script>
     var searchId = null;
     $(function () {
-        for (var i = 0; i < 5; i++) {
+        for (var i = 0; i < {{ app.config.plg_related_product_count }}; i++) {
             var $select = $("#admin_product_related_collection_" + i + "_ChildProduct :selected");
             $("#view_" + i).text($select.text());
         }

--- a/ServiceProvider/RelatedProductServiceProvider.php
+++ b/ServiceProvider/RelatedProductServiceProvider.php
@@ -14,6 +14,7 @@ namespace Plugin\RelatedProduct\ServiceProvider;
 use Eccube\Application;
 use Silex\Application as BaseApplication;
 use Silex\ServiceProviderInterface;
+use Symfony\Component\Yaml\Yaml;
 
 class RelatedProductServiceProvider implements ServiceProviderInterface
 {
@@ -42,6 +43,18 @@ class RelatedProductServiceProvider implements ServiceProviderInterface
         $app['eccube.plugin.service.related_product'] = $app->share(function () use ($app) {
             return new \Plugin\RelatedProduct\Service\RelatedProductService($app);
         });
+
+        // Config
+        $app['config'] = $app->share($app->extend('config', function ($configAll) {
+            $configYml = __DIR__ . '/../config/config.yml';
+            if (file_exists($configYml)) {
+                $config = Yaml::parse($configYml);
+                if (is_array($config)) {
+                    $configAll = array_merge($configAll, $config);
+                }
+            }
+            return $configAll;
+        }));
     }
 
     public function boot(BaseApplication $app)

--- a/config/config.yml
+++ b/config/config.yml
@@ -1,0 +1,1 @@
+plg_related_product_count: 5


### PR DESCRIPTION
config.yamlでなく管理画面上から設定の方がよければ、その方にお任せします。
