### PR TITLE
商品登録画面の関連商品自動表示

### DIFF
--- a/Event.php
+++ b/Event.php
@@ -162,6 +162,10 @@ class Event
 
         $form->handleRequest($request);
 
+        $ExistsRelativeProducts = array_filter($form['related_collection']->getData(), function ($v) {
+            return !is_null($v->getChildProduct());
+        });
+
         // 商品検索フォーム
         $searchForm = $app['form.factory']
             ->createBuilder('admin_search_product')
@@ -171,6 +175,7 @@ class Event
             'RelatedProduct/Resource/template/Admin/related_product.twig',
             array(
                 'form' => $form->createView(),
+                'toggleActive' => (count($ExistsRelativeProducts) > 0),
             )
         );
         $modal = $app->renderView(

--- a/Resource/template/Admin/related_product.twig
+++ b/Resource/template/Admin/related_product.twig
@@ -35,7 +35,7 @@ $(function() {
             <svg class="cb cb-angle-down icon_down"> <use xlink:href="#cb-angle-down" /></svg>
         </h3>
     </div><!-- /.box-header -->
-    <div class="box-body accpanel">
+    <div class="box-body accpanel" style="{% if toggleActive %}display: block;{% endif %}">
 
         {% for child in form.related_collection %}
             <div class="form-group">


### PR DESCRIPTION
関連商品が存在する場合、読み込み時にアコーディオンをアクティブにする。
