### PR TITLE
travisCIの複数エラー対応/テストパターン変更

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ php:
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
+
+dist: precise
 
 env:
   # plugin code

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,7 @@ before_script:
 script:
   # exec phpunit on ec-cube
   - phpunit app/Plugin/${PLUGIN_CODE}/Tests
-  - if [[ $PHP_SAPI != 'phpdbg' ]]; then ./vendor/bin/phpunit ; fi
+  - if [[ $PHP_SAPI != 'phpdbg' ]]; then ./vendor/bin/phpunit -c app/Plugin/${PLUGIN_CODE}/phpunit.xml.dist --coverage-clover=coverage.clover ; fi
 
 after_script:
   # disable plugin

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,9 @@ env:
     - ECCUBE_VERSION=master DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
     - ECCUBE_VERSION=master DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres
     - ECCUBE_VERSION=master DB=sqlite
+    # ec-cube 3.0.9
+    # - ECCUBE_VERSION=3.0.9 DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
+    # - ECCUBE_VERSION=3.0.9 DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres
     # ec-cube 3.0.15
     - ECCUBE_VERSION=3.0.15 DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
     - ECCUBE_VERSION=3.0.15 DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,8 @@ before_script:
 
 script:
   # exec phpunit on ec-cube
-  - phpunit ./vendor/bin/phpunit
+  - phpunit app/Plugin/${PLUGIN_CODE}/Tests
+  - if [[ $PHP_SAPI != 'phpdbg' ]]; then ./vendor/bin/phpunit ; fi
   - if [[ $TRAVIS_PHP_VERSION =~ ^[7] ]]; then ./vendor/bin/phpunit -c app/Plugin/${PLUGIN_CODE}/phpunit.xml.dist --coverage-clover=coverage.clover ; fi
 
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,8 @@ env:
     - ECCUBE_VERSION=master DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres
     - ECCUBE_VERSION=master DB=sqlite
     # ec-cube 3.0.9
-    - ECCUBE_VERSION=3.0.9 DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
-    - ECCUBE_VERSION=3.0.9 DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres
+    # - ECCUBE_VERSION=3.0.9 DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
+    # - ECCUBE_VERSION=3.0.9 DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres
     # ec-cube 3.0.15
     - ECCUBE_VERSION=3.0.15 DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
     - ECCUBE_VERSION=3.0.15 DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,6 @@ env:
     - ECCUBE_VERSION=master DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
     - ECCUBE_VERSION=master DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres
     - ECCUBE_VERSION=master DB=sqlite
-    # ec-cube 3.0.9
-    # - ECCUBE_VERSION=3.0.9 DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
-    # - ECCUBE_VERSION=3.0.9 DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres
     # ec-cube 3.0.15
     - ECCUBE_VERSION=3.0.15 DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
     - ECCUBE_VERSION=3.0.15 DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,7 @@ before_script:
 
 script:
   # exec phpunit on ec-cube
-  - phpunit app/Plugin/${PLUGIN_CODE}/Tests
+  - phpunit ./vendor/bin/phpunit
   - if [[ $TRAVIS_PHP_VERSION =~ ^[7] ]]; then ./vendor/bin/phpunit -c app/Plugin/${PLUGIN_CODE}/phpunit.xml.dist --coverage-clover=coverage.clover ; fi
 
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,7 +82,6 @@ script:
   # exec phpunit on ec-cube
   - phpunit app/Plugin/${PLUGIN_CODE}/Tests
   - if [[ $PHP_SAPI != 'phpdbg' ]]; then ./vendor/bin/phpunit ; fi
-  - if [[ $TRAVIS_PHP_VERSION =~ ^[7] ]]; then ./vendor/bin/phpunit -c app/Plugin/${PLUGIN_CODE}/phpunit.xml.dist --coverage-clover=coverage.clover ; fi
 
 after_script:
   # disable plugin


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
### エラー対応内容
+ vendorに同梱しているphpunitを利用するように変更
+ [Travic CIのUbuntuイメージの変更](https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming?utm_source=web&utm_medium=banner&&utm_campaign=trusty-default)に対応

### テストパターンの変更
+ php7.1をテスト実施対象に追加

ref: https://github.com/EC-CUBE/ec-cube/pull/2433