### PR TITLE
2、3カラム目のレイアウトにすると関連商品がずれて表示されてしまう不具合修正

### DIFF
--- a/Resource/template/front/related_product.twig
+++ b/Resource/template/front/related_product.twig
@@ -1,6 +1,6 @@
 <script>
     $(function () {
-        $("#RelatedProduct-product_area").appendTo(".ec-layoutRole__main");
+        $('#RelatedProduct-product_area').appendTo($('.ec-layoutRole__main, .ec-layoutRole__mainWithColumn, .ec-layoutRole__mainBetweenColumn'));
     });
 </script>
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,9 +38,9 @@ install:
 
   - git clone https://github.com/EC-CUBE/ec-cube.git %BASE_DIR%
   - cd %BASE_DIR%
-  - git checkout -b %BRANCH% origin/%BRANCH%
+  - git checkout origin/%BRANCH%
   # see https://github.com/phpmd/phpmd/blob/master/appveyor.yml#L10-L13
-  - cinst -y OpenSSL.Light
+  - cinst -y OpenSSL.Light --version 1.1.1
   - SET PATH=C:\Program Files\OpenSSL;%PATH%
   - sc config wuauserv start= auto
   - net start wuauserv


### PR DESCRIPTION
```
$("#RelatedProduct-product_area").appendTo(".ec-layoutRole__main");
```
の指定だと2、3カラム表示時にずれて表示されてしまうため、
`ec-layoutRole__mainWithColumn` と `ec-layoutRole__mainBetweenColumn`
も追加する。